### PR TITLE
remove unique constraint from timestamp index

### DIFF
--- a/src/services/graphqlsettings/datasources/event.ts
+++ b/src/services/graphqlsettings/datasources/event.ts
@@ -10,7 +10,7 @@ class EventAPI {
   }
 
   createIndex() {
-    this.datastore.ensureIndex({ fieldName: 'timestamp', unique: true }, function (err) {
+    this.datastore.ensureIndex({ fieldName: 'timestamp' }, function (err) {
       if (!err) {
         console.log("index created")
         return


### PR DESCRIPTION
for now: need to remove unique constraint for timestamp index.
Now: when inserting events seconds & milliseconds of the corresponding timestamp are set to 0, which may result in index conflicts. 
Until this issue is fixed, we can not use the unique constraint :(